### PR TITLE
Add devenv/Nix for reproducible development environment

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -193,6 +193,7 @@ jobs:
           track_progress: true
           prompt_file: review_prompt.txt
           claude_args: |
+            --verbose
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__pal__codereview,mcp__pal__consensus,Bash(gh pr comment:*),Read,Glob,Grep"
             --append-system-prompt "ultrathink"
 
@@ -251,6 +252,7 @@ jobs:
             Use ```suggestion blocks for fixes.
 
           claude_args: |
+            --verbose
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Read,Glob,Grep"
             --append-system-prompt "ultrathink"
 
@@ -279,6 +281,7 @@ jobs:
           trigger_phrase: "@claude"
           track_progress: true
           claude_args: |
+            --verbose
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(git:*),Read,Glob,Grep,Write,Edit"
             --append-system-prompt "ultrathink"
 
@@ -320,5 +323,6 @@ jobs:
 
             Always create the actual PR - do not just provide a link.
           claude_args: |
+            --verbose
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr:*),Bash(gh issue:*),Bash(git:*),Read,Glob,Grep,Write,Edit"
             --append-system-prompt "ultrathink"

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -189,11 +189,12 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: "claude-sonnet-4-20250514"
+          model: "claude-opus-4-20250514"
           track_progress: true
           prompt_file: review_prompt.txt
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,mcp__pal__codereview,mcp__pal__consensus,Bash(gh pr comment:*),Read,Glob,Grep"
+            --append-system-prompt "ultrathink"
 
   # Stage 3: Security review (runs in parallel with Stage 1, independent of chunks)
   review-security:
@@ -212,7 +213,7 @@ jobs:
         uses: ./.github/actions/claude-code-action
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: "claude-sonnet-4-20250514"
+          model: "claude-opus-4-20250514"
           track_progress: true
           prompt: |
             Perform a security-focused review of ALL changes in this PR.
@@ -251,6 +252,7 @@ jobs:
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Read,Glob,Grep"
+            --append-system-prompt "ultrathink"
 
   # ============================================================
   # COMMENT-TRIGGERED TASKS (@claude mentions)
@@ -273,11 +275,12 @@ jobs:
         uses: ./.github/actions/claude-code-action
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: "claude-sonnet-4-20250514"
+          model: "claude-opus-4-20250514"
           trigger_phrase: "@claude"
           track_progress: true
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh issue comment:*),Bash(git:*),Read,Glob,Grep,Write,Edit"
+            --append-system-prompt "ultrathink"
 
   # ============================================================
   # ISSUE-TRIGGERED TASKS (claude label or assignment)
@@ -304,9 +307,10 @@ jobs:
         uses: ./.github/actions/claude-code-action
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          model: "claude-sonnet-4-20250514"
+          model: "claude-opus-4-20250514"
           label_trigger: "claude"
           track_progress: true
           show_full_output: true
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr:*),Bash(gh issue:*),Bash(git:*),Read,Glob,Grep,Write,Edit"
+            --append-system-prompt "ultrathink"


### PR DESCRIPTION
## Summary
- Add devenv and Nix configuration for reproducible development environments
- Add CI workflow with Nix caching via Cachix for fast successive runs
- Add PAL MCP Server integration to review workflow

## Changes
- `devenv.nix` - Main devenv config with Python 3.12, Node 20, uv, build tools
- `devenv.yaml` - Inputs configuration (nixpkgs + nixpkgs-python)
- `.envrc` - direnv integration for automatic environment activation
- `.gitignore` - Excludes devenv paths and common patterns
- `.github/workflows/ci.yml` - New CI workflow using devenv with Cachix caching
- `.github/workflows/review.yml` - Added PAL MCP Server setup for multi-model consensus
- `README.md` - Updated quick start with devenv instructions

## Developer Experience

### Before
```bash
# Install Python 3.12.11 somehow
# Install Node 20 somehow
# Install uv somehow
cd review_eval
uv sync
```

### After
```bash
devenv shell    # Everything ready
dev-setup       # Install Python deps
test            # Run tests
```

## Available Scripts
- `dev-setup` - Install Python dependencies
- `test` - Run pytest
- `docs-serve` - Serve documentation locally
- `docs-build` - Build documentation
- `index-repo` - Index repository for semantic search
- `lint` - Run ruff linter
- `format` - Format code with ruff

## Test plan
- [ ] Verify `devenv shell` builds successfully
- [ ] Verify CI workflow runs with caching
- [ ] Verify PAL MCP Server installs in review workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)